### PR TITLE
Remove navp_faker, add gripper joints

### DIFF
--- a/config/ros_control_sim.yaml
+++ b/config/ros_control_sim.yaml
@@ -60,3 +60,5 @@ whole_body_controller:
   - neck_wrist_1_joint
   - neck_wrist_2_joint
   - neck_wrist_3_joint
+  - left_gripper_joint
+  - right_gripper_joint

--- a/launch/ros_control_sim.launch
+++ b/launch/ros_control_sim.launch
@@ -13,6 +13,7 @@
 
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" />
 
-  <include file="$(find iai_pr2_sim)/launch/fake_localization.launch" />
-
+  <!--  <include file="$(find iai_pr2_sim)/launch/fake_localization.launch" />-->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="fake_odom"
+        output="screen" args="0 0 0 0 0 0 map odom" />
 </launch>


### PR DESCRIPTION
With giskard the navp_faker interfers with publishing base_footprint.
Also, if the faker is used, it's better to call the node directly than fetching from iai_pr2_sim, since that package shouldn't be required for Boxy's sim.